### PR TITLE
Handle Bybit schema changes and interval normalization

### DIFF
--- a/image-prompt-app/backend/backend/bybit/__init__.py
+++ b/image-prompt-app/backend/backend/bybit/__init__.py
@@ -1,0 +1,6 @@
+"""Utilities for working with Bybit API responses."""
+
+__all__ = [
+    "models",
+    "parsers",
+]

--- a/image-prompt-app/backend/backend/bybit/models.py
+++ b/image-prompt-app/backend/backend/bybit/models.py
@@ -1,0 +1,55 @@
+"""Typed models representing Bybit instrument responses."""
+from __future__ import annotations
+
+from typing import List, Optional
+
+from pydantic import BaseModel, Field
+
+
+class PriceFilter(BaseModel):
+    tickSize: Optional[str] = None
+
+
+class LotSizeFilter(BaseModel):
+    maxOrderQty: Optional[str] = None
+    minOrderQty: Optional[str] = None
+    qtyStep: Optional[str] = None
+
+
+class LeverageFilter(BaseModel):
+    minLeverage: Optional[str] = None
+    maxLeverage: Optional[str] = None
+    leverageStep: Optional[str] = None
+
+
+class FeeRates(BaseModel):
+    takerFeeRate: Optional[str] = None
+    makerFeeRate: Optional[str] = None
+
+
+class RiskParameters(BaseModel):
+    maintainMarginRate: Optional[str] = None
+    initialMarginRate: Optional[str] = None
+
+
+class BybitInstrument(BaseModel):
+    symbol: Optional[str] = None
+    contractSize: Optional[str] = None
+    contractVal: Optional[str] = None
+    priceFilter: Optional[PriceFilter] = None
+    lotSizeFilter: Optional[LotSizeFilter] = None
+    leverageFilter: Optional[LeverageFilter] = None
+    feeRates: Optional[FeeRates] = None
+    riskParameters: Optional[RiskParameters] = None
+    fundingInterval: Optional[str] = None
+
+
+class InstrumentsResult(BaseModel):
+    category: Optional[str] = None
+    list: List[BybitInstrument] = Field(default_factory=list)
+
+
+class InstrumentsResponse(BaseModel):
+    retCode: int
+    retMsg: Optional[str] = None
+    result: Optional[InstrumentsResult] = None

--- a/image-prompt-app/backend/backend/bybit/parsers.py
+++ b/image-prompt-app/backend/backend/bybit/parsers.py
@@ -1,0 +1,78 @@
+"""Helpers for normalising Bybit instrument payloads."""
+from __future__ import annotations
+
+import logging
+from typing import Any, Mapping, Optional
+
+logger = logging.getLogger(__name__)
+
+
+def to_float(value: Any, default: Optional[float] = None) -> Optional[float]:
+    """Convert a Bybit numeric string to float, returning ``default`` on failure."""
+
+    if value is None:
+        return default
+    if isinstance(value, (int, float)):
+        return float(value)
+    if isinstance(value, str):
+        try:
+            return float(value)
+        except ValueError:
+            logger.debug("Unable to parse float from value %s", value)
+            return default
+    return default
+
+
+def to_int(value: Any, default: Optional[int] = None) -> Optional[int]:
+    """Convert a Bybit numeric string to int, returning ``default`` on failure."""
+
+    if value is None:
+        return default
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float):
+        return int(value)
+    if isinstance(value, str):
+        try:
+            return int(float(value))
+        except ValueError:
+            logger.debug("Unable to parse int from value %s", value)
+            return default
+    return default
+
+
+def pick(payload: Mapping[str, Any], *path: str) -> Any:
+    """Safely walk nested mappings using ``path`` keys."""
+
+    current: Any = payload
+    for key in path:
+        if isinstance(current, Mapping) and key in current:
+            current = current[key]
+        else:
+            return None
+    return current
+
+
+def get_contract_size(payload: Mapping[str, Any], category: str) -> float:
+    """Resolve contract size for an instrument regardless of schema revision."""
+
+    for candidate in ("contractSize", "contractVal"):
+        if candidate in payload and payload[candidate] is not None:
+            value = to_float(payload[candidate])
+            if value:
+                return value
+
+    logger.warning(
+        "Bybit instrument missing contract size field; defaulting to 1.0 for %s", payload.get("symbol")
+    )
+    if category.lower() == "linear":
+        return 1.0
+    return 1.0
+
+
+__all__ = [
+    "get_contract_size",
+    "pick",
+    "to_float",
+    "to_int",
+]

--- a/image-prompt-app/backend/tests/test_bybit_specs.py
+++ b/image-prompt-app/backend/tests/test_bybit_specs.py
@@ -1,0 +1,104 @@
+"""Tests for Bybit instrument specification parsing."""
+from __future__ import annotations
+
+from typing import Any, Dict
+
+import pytest
+from fastapi.testclient import TestClient
+
+from backend import crypto
+from backend.app import app
+
+
+class MockResponse:
+    def __init__(self, payload: Dict[str, Any]) -> None:
+        self._payload = payload
+
+    def raise_for_status(self) -> None:  # pragma: no cover - success path only
+        return None
+
+    def json(self) -> Dict[str, Any]:
+        return self._payload
+
+
+class MockAsyncClient:
+    def __init__(self, payload: Dict[str, Any]) -> None:
+        self._payload = payload
+
+    async def __aenter__(self) -> "MockAsyncClient":
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb) -> None:
+        return None
+
+    async def get(self, url: str, params: Dict[str, Any] | None = None) -> MockResponse:
+        return MockResponse(self._payload)
+
+
+def _build_instrument_response(field: str) -> Dict[str, Any]:
+    instrument: Dict[str, Any] = {
+        "symbol": "BTCUSDT",
+        field: "1",
+        "priceFilter": {"tickSize": "0.10"},
+        "lotSizeFilter": {
+            "minOrderQty": "0.001",
+            "qtyStep": "0.001",
+            "maxOrderQty": "100",
+        },
+        "leverageFilter": {"minLeverage": "1", "maxLeverage": "100"},
+        "feeRates": {"takerFeeRate": "0.0006", "makerFeeRate": "0.0001"},
+        "riskParameters": {
+            "maintainMarginRate": "0.005",
+            "initialMarginRate": "0.01",
+        },
+        "fundingInterval": "480",
+    }
+    return {
+        "retCode": 0,
+        "retMsg": "OK",
+        "result": {
+            "category": "linear",
+            "list": [instrument],
+        },
+    }
+
+
+@pytest.fixture
+def client() -> TestClient:
+    return TestClient(app)
+
+
+def _patch_async_client(monkeypatch: pytest.MonkeyPatch, payload: Dict[str, Any]) -> None:
+    def _factory(*args: Any, **kwargs: Any) -> MockAsyncClient:
+        return MockAsyncClient(payload)
+
+    monkeypatch.setattr(crypto.httpx, "AsyncClient", _factory)
+
+
+@pytest.mark.parametrize("field", ["contractSize", "contractVal"])
+def test_get_bybit_specs_handles_contract_fields(field: str, client: TestClient, monkeypatch: pytest.MonkeyPatch) -> None:
+    payload = _build_instrument_response(field)
+    crypto.futures_specs_cache.clear()
+    _patch_async_client(monkeypatch, payload)
+
+    response = client.post(
+        "/api/crypto/bybit/specs",
+        json={"symbol": "BTCUSDT", "category": "linear"},
+    )
+    assert response.status_code == 200, response.json()
+    data = response.json()
+
+    assert data["symbol"] == "BTCUSDT"
+    assert data["category"] == "linear"
+    assert data["contract_size"] == 1.0
+    assert data["tick_size"] == 0.10
+    assert data["qty_step"] == 0.001
+    assert data["min_order_qty"] == 0.001
+    assert data["max_order_qty"] == 100.0
+    assert data["leverage_min"] == 1.0
+    assert data["leverage_max"] == 100.0
+    # Legacy keys remain populated for backwards compatibility.
+    assert data["min_qty"] == data["min_order_qty"]
+    assert data["step_size"] == data["qty_step"]
+    assert data["max_leverage"] == data["leverage_max"]
+

--- a/image-prompt-app/backend/tests/test_indicator_dashboard_interval.py
+++ b/image-prompt-app/backend/tests/test_indicator_dashboard_interval.py
@@ -1,0 +1,88 @@
+"""Tests for indicator dashboard interval handling."""
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+import pytest
+from fastapi.testclient import TestClient
+
+from backend import crypto
+from backend.app import app
+
+
+@pytest.fixture
+def client() -> TestClient:
+    return TestClient(app)
+
+
+@pytest.fixture
+def sample_kline() -> List[List[float]]:
+    candles: List[List[float]] = []
+    for i in range(300):
+        base = 30000 + i
+        candles.append(
+            [
+                float(i * 60_000),
+                float(base),
+                float(base + 50),
+                float(base - 50),
+                float(base + 10),
+                float(100 + i),
+                float(i * 60_000 + 59_000),
+                float(1000 + i),
+                int(10 + i),
+                float(10 + i),
+                float(20 + i),
+                0,
+            ]
+        )
+    return candles
+
+
+@pytest.fixture
+def patched_data_sources(monkeypatch: pytest.MonkeyPatch, sample_kline: List[List[float]]):
+    async def fake_get_kline(symbol: str, interval: str):
+        return sample_kline
+
+    async def fake_fetch(endpoint: str, symbol: str, params: Dict[str, Any]):
+        if "funding" in endpoint:
+            return [{"fundingRate": "0.0001"} for _ in range(50)]
+        if "open-interest" in endpoint:
+            return [{"openInterest": str(1_000 + i)} for i in range(50)]
+        return []
+
+    monkeypatch.setattr(crypto, "get_kline", fake_get_kline)
+    monkeypatch.setattr(crypto, "_fetch_bybit_data", fake_fetch)
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        ("15m", "15m"),
+        ("15", "15m"),
+        (15, "15m"),
+        ("60", "1h"),
+        ("1h", "1h"),
+        ("240m", "4h"),
+        ("4h", "4h"),
+        ("1440", "1d"),
+        ("1d", "1d"),
+    ],
+)
+def test_normalize_interval_variants(raw: Any, expected: str) -> None:
+    assert crypto.normalize_interval(raw) == expected
+
+
+@pytest.mark.parametrize("interval", ["15m", "15", "1h", "60", "4h", "240m"])
+def test_indicator_dashboard_accepts_common_intervals(
+    interval: str, client: TestClient, patched_data_sources
+) -> None:
+    response = client.get(
+        "/api/crypto/indicator_dashboard",
+        params={"symbol": "BTCUSDT", "interval": interval},
+    )
+    assert response.status_code == 200, response.text
+    data = response.json()
+    assert "indicators" in data
+    assert len(data["indicators"]) > 0
+


### PR DESCRIPTION
## Summary
- add Bybit response models and parsing helpers to gracefully handle contract size schema changes and missing numeric fields
- normalize indicator dashboard intervals, reuse the canonical value across downstream requests, and harden indicator calculations against column name variations
- add tests covering Bybit specs parsing variants and interval normalization/endpoints

## Testing
- pytest

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690ea59c5bd88326821316021a88924f)